### PR TITLE
Enhance config loading

### DIFF
--- a/optionstrader.py
+++ b/optionstrader.py
@@ -66,10 +66,20 @@ def print_and_write(lines):
             out.write(line + "\n")
 
 def load_trade_config(path):
-    """Load and validate trade configuration from a JSON file."""
-    if not os.path.exists(path):
+    """Load and validate trade configuration from a JSON file.
+
+    The function first attempts to read ``path`` as provided. If that fails and
+    ``path`` is a relative location, it falls back to searching for the file in
+    the directory of this script. This allows the script to be relocated without
+    requiring absolute paths in helper scripts like ``run.bat``.
+    """
+    path = os.path.expanduser(os.path.expandvars(path))
+    candidate = path
+    if not os.path.isabs(candidate) and not os.path.exists(candidate):
+        candidate = os.path.join(script_dir, candidate)
+    if not os.path.exists(candidate):
         raise FileNotFoundError(f"Trade config file not found: {path}")
-    with open(path) as f:
+    with open(candidate) as f:
         cfg = json.load(f)
     for field in ("symbol", "side", "quantity"):
         if field not in cfg or cfg[field] in (None, ""):

--- a/run.bat
+++ b/run.bat
@@ -1,4 +1,5 @@
 @echo off
 pushd "%~dp0"
-python optionstrader.py "C:\Users\User\OneDrive\Documents\CRYPTO\PYTHON\CRYPTO\optionstrader\trade_config.json"
+REM Call the script with the config file located next to this batch file.
+python optionstrader.py trade_config.json
 pause

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import optionstrader
+
+def test_load_trade_config_fallback(tmp_path, monkeypatch):
+    """load_trade_config should locate the file in the script directory when the working directory doesn't contain it."""
+    monkeypatch.chdir(tmp_path)
+    cfg = optionstrader.load_trade_config('trade_config.json')
+    assert {'symbol', 'side', 'quantity'}.issubset(cfg)


### PR DESCRIPTION
## Summary
- allow `load_trade_config` to find config relative to script directory
- use relative path in `run.bat`
- add regression test for config loading fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430af165dc83219a6cd84d90b0b1f2