### PR TITLE
Ensure choose_symbol_by_risk keeps requested expiry

### DIFF
--- a/optionstrader.py
+++ b/optionstrader.py
@@ -172,7 +172,7 @@ def choose_symbol_by_risk(base_symbol, risk_usd, qty, base_url=BASE_URL):
     parts = base_symbol.split('-')
     if len(parts) < 5:
         return base_symbol, 0.0
-    base_coin, _expiry, _strike, opt_type, _quote = parts
+    base_coin, expiry_token, _strike, opt_type, _quote = parts
     instruments = fetch_option_instruments(base_coin, option_type=opt_type, base_url=base_url)
     if not instruments:
         return base_symbol, 0.0
@@ -184,6 +184,12 @@ def choose_symbol_by_risk(base_symbol, risk_usd, qty, base_url=BASE_URL):
             if dt:
                 return dt
         return datetime.max
+
+    desired_expiry = _parse_expiry(expiry_token)
+    if desired_expiry:
+        same_expiry = [i for i in instruments if expiry_from_symbol(i.get('symbol', '')) == desired_expiry]
+        if same_expiry:
+            instruments = same_expiry
 
     instruments.sort(key=lambda inst: expiry_from_symbol(inst.get('symbol', '')))
     first_expiry = expiry_from_symbol(instruments[0].get('symbol', ''))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,6 +111,29 @@ def test_choose_symbol_by_risk_respects_option_type(monkeypatch):
     assert sym.endswith('-P')
 
 
+def test_choose_symbol_by_risk_preserves_expiry(monkeypatch):
+    instruments = [
+        {'symbol': 'BTC-07JUN25-100000-P'},
+        {'symbol': 'BTC-14JUN25-100000-P'},
+    ]
+    prices = {
+        'BTC-07JUN25-100000-P': {'markPrice': '1'},
+        'BTC-14JUN25-100000-P': {'markPrice': '0.5'},
+    }
+
+    def fake_insts(base_coin, expiry=None, option_type=None, base_url=None):
+        assert option_type == 'P'
+        return instruments
+
+    def fake_tick(symbol, base_url=None):
+        return prices[symbol]
+
+    monkeypatch.setattr(optionstrader, 'fetch_option_instruments', fake_insts)
+    monkeypatch.setattr(optionstrader, 'fetch_option_ticker', fake_tick)
+    sym, _ = optionstrader.choose_symbol_by_risk('BTC-07JUN25-105000-P-USDT', 1, 1)
+    assert sym.startswith('BTC-07JUN25')
+
+
 def test_compute_order_qty_floor():
     qty = optionstrader.compute_order_qty(0.1, 100)
     assert qty == optionstrader.MIN_ORDER_QTY


### PR DESCRIPTION
## Summary
- respect expiry token when selecting a symbol by risk
- test choose_symbol_by_risk keeps the same expiry if available

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684376fea54083218f4f72d25279a65b