### PR TITLE
Add Telegram log upload

### DIFF
--- a/alert_server.py
+++ b/alert_server.py
@@ -24,7 +24,10 @@ def webhook():
         qty = optionstrader.compute_order_qty(risk_usd, price)
     key, secret = optionstrader.get_api_credentials(cfg)
     trader = optionstrader.BybitOptionsTrader(key, secret, optionstrader.BASE_URL)
-    trader.place_and_log(symbol, side, qty, None, 'GTC')
+    _trades, trade_log = trader.place_and_log(symbol, side, qty, None, 'GTC')
+    token, chat_id = optionstrader.get_telegram_credentials(cfg)
+    optionstrader.send_telegram_document(trade_log, token, chat_id,
+                                         caption=f"{side} {qty} {symbol}")
     return jsonify({'message': 'order sent', 'qty': qty, 'symbol': symbol}), 200
 
 if __name__ == '__main__':

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,0 +1,40 @@
+import optionstrader
+
+def test_get_telegram_credentials_env_override(monkeypatch):
+    cfg = {'telegram_token': 'T', 'telegram_chat_id': 'C'}
+    monkeypatch.setenv('TELEGRAM_TOKEN', 'ET')
+    monkeypatch.setenv('TELEGRAM_CHAT_ID', 'EC')
+    token, chat_id = optionstrader.get_telegram_credentials(cfg)
+    assert token == 'ET' and chat_id == 'EC'
+
+
+def test_send_telegram_document_calls_post(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_post(url, data=None, files=None, timeout=10):
+        called['url'] = url
+        called['data'] = data
+        called['sent'] = files['document'].read()
+        class Resp:
+            pass
+        return Resp()
+
+    monkeypatch.setattr(optionstrader.requests, 'post', fake_post)
+    f = tmp_path / 'f.log'
+    f.write_text('hi')
+    optionstrader.send_telegram_document(str(f), 'tok', 'chat')
+    assert called['url'].endswith('/sendDocument')
+    assert called['data']['chat_id'] == 'chat'
+    assert called['sent'] == b'hi'
+
+
+def test_send_telegram_document_no_creds(monkeypatch, tmp_path):
+    posted = False
+    def fake_post(*a, **k):
+        nonlocal posted
+        posted = True
+    monkeypatch.setattr(optionstrader.requests, 'post', fake_post)
+    f = tmp_path / 'f.log'
+    f.write_text('x')
+    optionstrader.send_telegram_document(str(f), '', '')
+    assert posted is False

--- a/trade_config.json
+++ b/trade_config.json
@@ -6,5 +6,7 @@
   "risk_usd": 2.20,
   "auto_trade": true,
   "api_key": "4LsBsDgCxjO02MQcSY",
-  "api_secret": "M40Sgh3yQKMywQMFXzR6sZmd6b7vhLeiiQvI"
+  "api_secret": "M40Sgh3yQKMywQMFXzR6sZmd6b7vhLeiiQvI",
+  "telegram_token": "YOUR_BOT_TOKEN",
+  "telegram_chat_id": "123456"
 }


### PR DESCRIPTION
## Summary
- allow log upload to Telegram
- send trade logs from alert server and main script
- show Telegram placeholders in config
- test Telegram helper functions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684376fea54083218f4f72d25279a65b