### PR TITLE
Add interactive menu for trading options

### DIFF
--- a/trade_config.json
+++ b/trade_config.json
@@ -8,5 +8,6 @@
   "api_key": "4LsBsDgCxjO02MQcSY",
   "api_secret": "M40Sgh3yQKMywQMFXzR6sZmd6b7vhLeiiQvI",
   "telegram_token": "7659321661:AAGuwYj6Hvt4t7lQhf3yeR2wzxo90GNnxi8",
-  "telegram_chat_id": "7812917757"
+  "telegram_chat_id": "7812917757",
+  "demo_balance": 10000.0
 }


### PR DESCRIPTION
## Summary
- implement menu-driven flow with options to manage orders
- add methods to query and modify orders and positions
- support updating demo account balance stored in config
- add optional `--no-menu` CLI flag to skip menu

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de31ab3a4832198e437d7c76517c9