### PR TITLE
Handle empty cancel-all gracefully

### DIFF
--- a/optionstrader.py
+++ b/optionstrader.py
@@ -378,7 +378,16 @@ class BybitOptionsTrader:
     def cancel_all_orders(self):
         """Cancel all open option orders."""
         body = {"category": "option"}
-        self._send_request("POST", "/v5/order/cancel-all", body)
+        try:
+            self._send_request("POST", "/v5/order/cancel-all", body)
+        except ApiException as exc:
+            # Bybit returns error 110008 when there are no active orders. This
+            # should not abort the cancel-all workflow, so we simply log and
+            # continue when that specific error occurs.
+            if "110008" in str(exc):
+                logger.info("No open orders to cancel")
+            else:
+                raise
 
     def close_position(self, symbol, side, qty):
         """Close a position using a market order."""


### PR DESCRIPTION
## Summary
- ignore Bybit error 110008 (no active orders) when cancelling
- log a message instead of raising an exception

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de9e7d99083218edacabdf701e8b5