### PR TITLE
Add menu option to export full trade history to CSV

### DIFF
--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -28,3 +28,22 @@ def test_export_recent_trade_history(tmp_path, monkeypatch):
     expected_time = expected_time.astimezone(ZoneInfo("Australia/Brisbane"))
     assert row["localTime"] == expected_time.strftime("%Y-%m-%d %H:%M:%S")
     assert abs(float(row["balance"]) - 100.0) < 1e-9
+
+
+def test_export_all_trade_history(tmp_path, monkeypatch):
+    ts = 1715000000000  # example timestamp in ms
+    trades = [{"execTime": ts, "execFee": "0.1", "closedPnl": "0.2"}]
+    monkeypatch.setattr(optionstrader, "script_dir", str(tmp_path))
+    trader = DummyTrader(trades)
+    optionstrader.export_all_trade_history(trader)
+    path = tmp_path / "all_trades.csv"
+    with open(path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    row = rows[0]
+    assert abs(float(row["netFee"]) - 0.1) < 1e-9
+    assert abs(float(row["netPnl"]) - 0.2) < 1e-9
+    expected_time = datetime.fromtimestamp(ts/1000, timezone.utc)
+    expected_time = expected_time.astimezone(ZoneInfo("Australia/Brisbane"))
+    assert row["localTime"] == expected_time.strftime("%Y-%m-%d %H:%M:%S")
+    assert abs(float(row["balance"]) - 100.0) < 1e-9


### PR DESCRIPTION
## Summary
- refactor trade history export to shared helper
- add `export_all_trade_history` function and menu option for full CSV export
- test coverage for exporting full history

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e78ce7f748321886ad9312836613e