### PR TITLE
Add component-based option symbol builder and UI fields

### DIFF
--- a/tests/test_build_option_symbol.py
+++ b/tests/test_build_option_symbol.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import optionstrader
+
+def test_build_option_symbol_basic():
+    sym = optionstrader.build_option_symbol('btc', '114000', 'put', '7/6/25', 'usdt')
+    assert sym == 'BTC-7JUN25-114000-P-USDT'
+
+def test_build_option_symbol_call():
+    sym = optionstrader.build_option_symbol('eth', '2500', 'CALL', '12/11/24', 'usdc')
+    assert sym == 'ETH-12NOV24-2500-C-USDC'

--- a/web_menu.py
+++ b/web_menu.py
@@ -99,12 +99,21 @@ def trade():
         risk_percent = float(form.get("risk_percent", 0) or 0)
         risk_usd = balance * risk_percent / 100
         qty = float(form.get("quantity", 0) or 0)
+        symbol = form.get("symbol", "")
+        if not symbol:
+            symbol = optionstrader.build_option_symbol(
+                form.get("base", ""),
+                form.get("strike", ""),
+                form.get("option_type", ""),
+                form.get("expiry", ""),
+                form.get("quote", "USDT"),
+            )
         if qty <= 0 and risk_usd > 0:
-            tick = optionstrader.fetch_option_ticker(form.get("symbol", ""))
+            tick = optionstrader.fetch_option_ticker(symbol)
             price = float(tick.get("markPrice", 0) or 0)
             qty = optionstrader.compute_order_qty(risk_usd, price)
         cfg = {
-            "symbol": form.get("symbol", ""),
+            "symbol": symbol,
             "side": form.get("side", "Buy"),
             "quantity": qty,
             "limit_price": float(form["limit_price"]) if form.get("limit_price") else None,
@@ -144,7 +153,11 @@ def trade():
         <p>Current Balance: {{balance}} USDT</p>
         <form method='post'>
         <table>
-        <tr><td>Symbol</td><td><input name='symbol'></td></tr>
+        <tr><td>Base</td><td><input name='base'></td></tr>
+        <tr><td>Strike</td><td><input name='strike'></td></tr>
+        <tr><td>Call/Put</td><td><input name='option_type'></td></tr>
+        <tr><td>Expiry (D/M/YY)</td><td><input name='expiry'></td></tr>
+        <tr><td>Quote</td><td><input name='quote' value='USDT'></td></tr>
         <tr><td>Side</td><td><input name='side' value='Buy'></td></tr>
         <tr><td>Quantity</td><td><input name='quantity' value='0'></td></tr>
         <tr><td>Limit Price</td><td><input name='limit_price'></td></tr>


### PR DESCRIPTION
## Summary
- allow building Bybit option symbols from parts like base, strike, expiry and type
- add matching inputs in the web interface and auto-format the final symbol
- cover symbol builder with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e99cae884832198c9373cd2070d9b