### PR TITLE
Add delivery history export options

### DIFF
--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -8,6 +8,8 @@ class DummyTrader:
         self.trades = trades
     def list_trade_history(self, start, end):
         return self.trades
+    def list_delivery_history(self, start, end):
+        return self.trades
     def get_wallet_balance(self, coin="USDT"):
         return 100.0
 
@@ -47,6 +49,59 @@ def test_export_all_trade_history(tmp_path, monkeypatch):
     expected_time = expected_time.astimezone(ZoneInfo("Australia/Brisbane"))
     assert row["localTime"] == expected_time.strftime("%Y-%m-%d %H:%M:%S")
     assert abs(float(row["balance"]) - 100.0) < 1e-9
+
+
+def test_export_recent_delivery_history(tmp_path, monkeypatch):
+    ts = 1715000000000
+    deliveries = [{"execTime": ts, "execFee": "0.1", "closedPnl": "0.2"}]
+    monkeypatch.setattr(optionstrader, "script_dir", str(tmp_path))
+    trader = DummyTrader(deliveries)
+    optionstrader.export_recent_delivery_history(trader, days=1)
+    path = tmp_path / "recent_deliveries.csv"
+    with open(path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    row = rows[0]
+    assert abs(float(row["netFee"]) - 0.1) < 1e-9
+    assert abs(float(row["netPnl"]) - 0.2) < 1e-9
+    expected_time = datetime.fromtimestamp(ts/1000, timezone.utc)
+    expected_time = expected_time.astimezone(ZoneInfo("Australia/Brisbane"))
+    assert row["localTime"] == expected_time.strftime("%Y-%m-%d %H:%M:%S")
+    assert abs(float(row["balance"]) - 100.0) < 1e-9
+
+
+def test_export_all_delivery_history(tmp_path, monkeypatch):
+    ts = 1715000000000
+    deliveries = [{"execTime": ts, "execFee": "0.1", "closedPnl": "0.2"}]
+    monkeypatch.setattr(optionstrader, "script_dir", str(tmp_path))
+    trader = DummyTrader(deliveries)
+    optionstrader.export_all_delivery_history(trader)
+    path = tmp_path / "all_deliveries.csv"
+    with open(path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    row = rows[0]
+    assert abs(float(row["netFee"]) - 0.1) < 1e-9
+    assert abs(float(row["netPnl"]) - 0.2) < 1e-9
+    expected_time = datetime.fromtimestamp(ts/1000, timezone.utc)
+    expected_time = expected_time.astimezone(ZoneInfo("Australia/Brisbane"))
+    assert row["localTime"] == expected_time.strftime("%Y-%m-%d %H:%M:%S")
+    assert abs(float(row["balance"]) - 100.0) < 1e-9
+
+
+def test_export_all_delivery_history_handles_error(tmp_path, monkeypatch, capsys):
+    class FailingTrader:
+        def list_delivery_history(self, start, end):
+            raise optionstrader.ApiException("boom")
+        def get_wallet_balance(self, coin="USDT"):
+            return 0.0
+
+    monkeypatch.setattr(optionstrader, "script_dir", str(tmp_path))
+    trader = FailingTrader()
+    optionstrader.export_all_delivery_history(trader)
+    captured = capsys.readouterr()
+    assert "Failed to retrieve delivery history" in captured.out
+    assert not (tmp_path / "all_deliveries.csv").exists()
 
 
 def test_export_all_trade_history_handles_error(tmp_path, monkeypatch, capsys):

--- a/web_menu.py
+++ b/web_menu.py
@@ -82,6 +82,8 @@ def index():
         <button onclick=\"location.href='/edit'\">Edit Open Order</button>
         <button onclick=\"location.href='/export_recent'\">Export Trade History (7 days)</button>
         <button onclick=\"location.href='/export_all'\">Export All Trade History</button>
+        <button onclick=\"location.href='/delivery_recent'\">Export Delivery History (7 days)</button>
+        <button onclick=\"location.href='/delivery_all'\">Export All Delivery History</button>
         <button onclick=\"location.href='/reduce'\">Place Reduce-Only Exits</button>
         """
     )
@@ -250,6 +252,28 @@ def export_all():
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         optionstrader.export_all_trade_history(t)
+    return _page("<pre>" + buf.getvalue() + "</pre><a href='/'>Back</a>")
+
+
+@app.route("/delivery_recent")
+def delivery_recent():
+    t = _get_trader()
+    if t is None:
+        return _page("No trader available. Place a trade first.<br><a href='/'>Back</a>")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        optionstrader.export_recent_delivery_history(t)
+    return _page("<pre>" + buf.getvalue() + "</pre><a href='/'>Back</a>")
+
+
+@app.route("/delivery_all")
+def delivery_all():
+    t = _get_trader()
+    if t is None:
+        return _page("No trader available. Place a trade first.<br><a href='/'>Back</a>")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        optionstrader.export_all_delivery_history(t)
     return _page("<pre>" + buf.getvalue() + "</pre><a href='/'>Back</a>")
 
 


### PR DESCRIPTION
## Summary
- Add helpers to fetch and export delivery records similar to trade history
- Expose delivery export as buttons in the web menu
- Test delivery export paths and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968af37fc88321b2833d12074363c1