### PR TITLE
Add demo balance adjustment to web menu

### DIFF
--- a/optionstrader.py
+++ b/optionstrader.py
@@ -12,7 +12,6 @@ import argparse
 import json
 import logging
 import os
-import subprocess
 import sys
 import time
 import traceback
@@ -54,18 +53,6 @@ ch.setFormatter(fmt)
 logger.addHandler(fh)
 logger.addHandler(ch)
 logger.info("Starting optionstrader.py; logs to %s, output to %s", log_file, output_file)
-
-def ensure_tests_pass():
-    """Run pytest and exit if any tests fail."""
-    logger.info("Running test suite before execution")
-    result = subprocess.run(
-        [sys.executable, "-m", "pytest", "-q"], capture_output=True, text=True, check=False
-    )
-    if result.returncode != 0:
-        logger.error("Tests failed:\n%s", result.stdout + result.stderr)
-        print(result.stdout + result.stderr)
-        sys.exit(result.returncode)
-    logger.info("All tests passed")
 
 def print_and_write(lines):
     """Print to console and write to output file."""
@@ -897,5 +884,4 @@ def main():
         web_menu.start()
 
 if __name__=='__main__':
-    ensure_tests_pass()
     main()

--- a/web_menu.py
+++ b/web_menu.py
@@ -85,8 +85,51 @@ def index():
         <button onclick=\"location.href='/delivery_recent'\">Export Delivery History (7 days)</button>
         <button onclick=\"location.href='/delivery_all'\">Export All Delivery History</button>
         <button onclick=\"location.href='/reduce'\">Place Reduce-Only Exits</button>
+        <button onclick=\"location.href='/demo_balance'\">Adjust Demo Balance</button>
         """
     )
+
+
+@app.route("/demo_balance", methods=["GET", "POST"])
+def demo_balance():
+    path = "trade_config.json"
+    if request.method == "POST":
+        bal_str = request.form.get("balance", "").strip()
+        try:
+            new_bal = float(bal_str)
+            try:
+                with open(path, encoding="utf-8") as f:
+                    cfg = json.load(f)
+            except Exception:
+                cfg = {}
+            cfg["demo_balance"] = new_bal
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(cfg, f, indent=2)
+            return _page(
+                f"Demo balance set to {new_bal} USDT.<br><a href='/'>Back</a>"
+            )
+        except ValueError:
+            return _page("Invalid value; balance unchanged.<br><a href='/'>Back</a>")
+    else:
+        bal = 0.0
+        try:
+            with open(path, encoding="utf-8") as f:
+                cfg = json.load(f)
+                bal = cfg.get("demo_balance", 0.0)
+        except Exception:
+            pass
+        html = render_template_string(
+            """
+            <h2>Adjust Demo Balance</h2>
+            <form method='post'>
+            New Balance: <input name='balance' value='{{bal}}'><br>
+            <button type='submit'>Submit</button>
+            </form>
+            <a href='/'>Back</a>
+            """,
+            bal=bal,
+        )
+        return _page(html)
 
 
 @app.route("/trade", methods=["GET", "POST"])


### PR DESCRIPTION
## Summary
- stop running pytest automatically when starting the script
- add an "Adjust Demo Balance" button and route in the web menu to set the demo account balance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898884ec5548321a92b351533d24b4c