### PR TITLE
Ensure demo balance updates propagate to trade page

### DIFF
--- a/tests/test_demo_balance.py
+++ b/tests/test_demo_balance.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+import web_menu
+
+
+def test_trade_page_uses_demo_balance():
+    cfg_path = Path("trade_config.json")
+    original = cfg_path.read_text(encoding="utf-8")
+    try:
+        cfg_path.write_text(json.dumps({"demo_balance": 123.45}), encoding="utf-8")
+        client = web_menu.app.test_client()
+        resp = client.get("/trade")
+        assert "Current Balance: 123.45 USDT" in resp.get_data(as_text=True)
+    finally:
+        cfg_path.write_text(original, encoding="utf-8")


### PR DESCRIPTION
## Summary
- Show stored demo balance on the Create Trade page
- Fall back to the demo balance if fetching wallet funds fails
- Test that demo balance value appears on trade page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988ec0a3548321b3ead1c2760c30eb