### PR TITLE
Round prices to tick size

### DIFF
--- a/tests/test_profit_targets.py
+++ b/tests/test_profit_targets.py
@@ -1,5 +1,6 @@
 import optionstrader
 
+
 class DummyTrader(optionstrader.BybitOptionsTrader):
     def __init__(self):
         pass
@@ -16,8 +17,9 @@ class DummyTrader(optionstrader.BybitOptionsTrader):
         }
 
 
-def test_set_profit_targets_places_order():
+def test_set_profit_targets_places_order(monkeypatch):
     trader = DummyTrader()
+    monkeypatch.setattr(optionstrader, "get_tick_size", lambda s: 0.1)
     optionstrader.set_profit_targets(trader)
     assert trader.called["side"] == "Sell"
     assert trader.called["price"] == 1.5


### PR DESCRIPTION
## Summary
- add cached helper to fetch tick size for an option symbol
- round prices to the instrument's tick size when placing and targeting orders
- adjust profit target tests to use fixed tick size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a163fe35088321abb104acff1661d9