### PR TITLE
Handle order failures when setting profit targets

### DIFF
--- a/optionstrader.py
+++ b/optionstrader.py
@@ -806,8 +806,14 @@ def set_profit_targets(trader, multiplier=2):
         if not symbol or not avg_price:
             continue
         target = avg_price * (multiplier + 1)
-        trader.place_order(symbol, "Sell", qty, target, "GTC", True)
-        print(f"Placed reduce-only Sell {qty} {symbol} @ {target}")
+        try:
+            trader.place_order(symbol, "Sell", qty, target, "GTC", True)
+            print(f"Placed reduce-only Sell {qty} {symbol} @ {target}")
+        except ApiException as exc:
+            print(
+                f"Warning: failed to place reduce-only Sell {qty} {symbol} @ {target}: {exc}"
+            )
+            continue
 
 
 def interactive_menu(cfg_path):

--- a/tests/test_profit_targets.py
+++ b/tests/test_profit_targets.py
@@ -35,3 +35,34 @@ def test_set_profit_targets_skips_shorts(monkeypatch):
     trader.place_order = fake_place_order
     optionstrader.set_profit_targets(trader)
     assert called is False
+
+
+def test_set_profit_targets_continues_on_error(capsys):
+    class ErrorTrader(optionstrader.BybitOptionsTrader):
+        def __init__(self):
+            self.calls = 0
+
+        def get_positions(self, symbol=None):
+            return [
+                {"symbol": "BTC-FAIL", "side": "Buy", "size": "1", "avgPrice": "0.5"},
+                {"symbol": "BTC-OK", "side": "Buy", "size": "1", "avgPrice": "0.5"},
+            ]
+
+        def place_order(self, symbol, side, qty, price=None, tif="GTC", is_exit=False):
+            self.calls += 1
+            if self.calls == 1:
+                raise optionstrader.ApiException("boom")
+            self.called = {
+                "symbol": symbol,
+                "side": side,
+                "qty": qty,
+                "price": price,
+                "is_exit": is_exit,
+            }
+
+    trader = ErrorTrader()
+    optionstrader.set_profit_targets(trader)
+    assert trader.calls == 2
+    assert trader.called["symbol"] == "BTC-OK"
+    captured = capsys.readouterr()
+    assert "Warning" in captured.out


### PR DESCRIPTION
## Summary
- wrap order placements in `set_profit_targets` with error handling
- add test to ensure processing continues after order failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a163ff756083219bb9dcf3608faf8a