### PR TITLE
Disable logger propagation to avoid duplicate messages

### DIFF
--- a/optionstrader.py
+++ b/optionstrader.py
@@ -53,6 +53,7 @@ fh.setFormatter(fmt)
 ch.setFormatter(fmt)
 logger.addHandler(fh)
 logger.addHandler(ch)
+logger.propagate = False
 logger.info("Starting optionstrader.py; logs to %s, output to %s", log_file, output_file)
 
 def print_and_write(lines):


### PR DESCRIPTION
## Summary
- Prevent log messages from bubbling up to the root logger by setting `logger.propagate = False` after configuring file and console handlers.

## Testing
- `python - <<'PY'
import logging
logging.basicConfig(level=logging.DEBUG)
import optionstrader
optionstrader.logger.info('Message X')
PY`
- `cat optionstrader.log`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16400318c83219577d3f55be0dc7b