### PR TITLE
Use price filter tick size

### DIFF
--- a/optionstrader.py
+++ b/optionstrader.py
@@ -193,7 +193,7 @@ def get_tick_size(symbol, base_url=BASE_URL):
     lst = data.get("result", {}).get("list", [])
     if not lst:
         raise RuntimeError(f"No instrument data for symbol: {symbol}")
-    tick = float(lst[0].get("lotSizeFilter", {}).get("tickSize", 0))
+    tick = float(lst[0].get("priceFilter", {}).get("tickSize", 0))
     _tick_size_cache[symbol] = tick
     return tick
 


### PR DESCRIPTION
## Summary
- Fetch tick size from `priceFilter` instead of `lotSizeFilter`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a168dc53ec83218dce140444394b7a