### PR TITLE
Validate tick size before rounding price

### DIFF
--- a/optionstrader.py
+++ b/optionstrader.py
@@ -201,6 +201,8 @@ def get_tick_size(symbol, base_url=BASE_URL):
 def round_to_tick(price, symbol):
     """Round ``price`` to the nearest tick for ``symbol``."""
     tick = get_tick_size(symbol)
+    if not tick:
+        raise ValueError(f"Tick size for {symbol} is zero or missing")
     price_dec = Decimal(str(price))
     tick_dec = Decimal(str(tick))
     rounded = (price_dec / tick_dec).quantize(Decimal('1'), rounding=ROUND_HALF_UP) * tick_dec

--- a/web_menu.py
+++ b/web_menu.py
@@ -254,7 +254,7 @@ def reduce():
             optionstrader.set_profit_targets(t)
     except Exception as exc:  # pragma: no cover - just in case
         app.logger.exception("Failed to set profit targets")
-        return _page(f"<pre>{exc}</pre><a href='/'>Back</a>")
+        return _page(f"<pre>Failed to set profit targets: {exc}</pre><a href='/'>Back</a>")
     return _page("<pre>" + buf.getvalue() + "</pre><a href='/'>Back</a>")
 
 


### PR DESCRIPTION
## Summary
- Raise an error when tick size is zero or missing in `round_to_tick`
- Surface failure details on `/reduce` route for clearer feedback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a168de46f88321bbf58c498c5229f8